### PR TITLE
Add a limit to how many comments are shown via a get request

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -35,6 +35,9 @@ import com.google.appengine.api.datastore.Entity;
 /** Servlet that returns some example content. TODO: modify this file to handle comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
+
+  private static final int DEFAULT_COMMENTS = 2;
+
   private class Comment {
       String name;
       String text;
@@ -63,10 +66,10 @@ public class DataServlet extends HttpServlet {
     try {
         requestAmount = Integer.parseInt(request.getParameter("amount"));
     } catch (NumberFormatException e) {
-        requestAmount = 0;
+        requestAmount = DEFAULT_COMMENTS;
     }
     if(requestAmount < 0) {
-        requestAmount = 0;
+        requestAmount = DEFAULT_COMMENTS;
     }
     //Reduce request size to be the comments size to not get exception
     if(requestAmount > comments.size()) {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -54,7 +54,7 @@ function createCommentDiv(comment) {
 }   
 
 function fetchComments() {
-    fetch("/data").then(response => response.json()).then((comments) => {
+    fetch("/data?amount=2").then(response => response.json()).then((comments) => {
         console.log(comments);
         let commentElem = document.getElementById("comments");
         comments.forEach(comment => {


### PR DESCRIPTION
Uses a get request to limit how many comments are shown to the browser via a get request which limits the size of the json