### PR TITLE
Add tests for optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/Event.java
@@ -23,7 +23,7 @@ import java.util.Set;
  * Event is the container class for when a specific group of people are meeting and are therefore
  * busy. Events are considered read-only.
  */
-public final class Event {
+public final class Event implements Comparable<Event>{
   private final String title;
   private final TimeRange when;
   private final Set<String> attendees = new HashSet<>();
@@ -74,6 +74,9 @@ public final class Event {
     // Return the attendees as an unmodifiable set so that the caller can't change our
     // internal data.
     return Collections.unmodifiableSet(attendees);
+  }
+  public int compareTo(Event eventB) {
+      return this.getWhen().start() - eventB.getWhen().start();
   }
 
   @Override

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -22,6 +22,7 @@ public final class FindMeetingQuery {
     long duration = request.getDuration();
     ArrayList<Event> allEvents = new ArrayList();
     Set<String> attendees = new HashSet<String>(request.getAttendees());
+    //Add all events that attendees go to
     for (Event event : events) {
         Set<String> curAttendees = new HashSet<String>(attendees);
         curAttendees.retainAll(event.getAttendees());
@@ -41,29 +42,28 @@ public final class FindMeetingQuery {
             if ((long) curRange.duration() >= request.getDuration()) {
                 times.add(curRange);
             }
-            
         }
+        //If next event overlaps with current, make start the greater of the two events
         if ((i != allEvents.size() - 1) && curTime.overlaps(allEvents.get(i+1).getWhen())) {
             start = Math.max(curTime.end(), start);
             cont = true;
         } else {
+            //If it doesn't overlap check gap during next iteration
             start = Math.max(curTime.end(), start);
             cont = false;
         }
-
+        //If last event check if end of day is a possible time
         if (i == allEvents.size() - 1) {
-            TimeRange curRange = TimeRange.fromStartEnd(start, 1440, false);
+            TimeRange curRange = TimeRange.fromStartEnd(start, TimeRange.END_OF_DAY, true);
             if ((long) curRange.duration() >= request.getDuration()) {
                 times.add(curRange);
             }
 
         }
     }
-    if (allEvents.size() == 0 && request.getDuration() <= 1440) {
-        times.add(TimeRange.fromStartEnd(0, 1440, false));
+    if (allEvents.size() == 0 && request.getDuration() <= TimeRange.END_OF_DAY) {
+        times.add(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY, true));
     }
     return times;
   }
-  
-
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,6 +15,7 @@
 package com.google.sps;
 
 import java.util.*;
+import java.lang.Math;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
@@ -43,9 +44,10 @@ public final class FindMeetingQuery {
             
         }
         if ((i != allEvents.size() - 1) && curTime.overlaps(allEvents.get(i+1).getWhen())) {
+            start = Math.max(curTime.end(), start);
             cont = true;
         } else {
-            start = curTime.end();
+            start = Math.max(curTime.end(), start);
             cont = false;
         }
 
@@ -57,7 +59,7 @@ public final class FindMeetingQuery {
 
         }
     }
-    if (allEvents.size() == 0) {
+    if (allEvents.size() == 0 && request.getDuration() <= 1440) {
         times.add(TimeRange.fromStartEnd(0, 1440, false));
     }
     return times;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -21,17 +21,35 @@ public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
     long duration = request.getDuration();
     ArrayList<Event> allEvents = new ArrayList();
+    ArrayList<Event> allEventsOptional = new ArrayList();
     Set<String> attendees = new HashSet<String>(request.getAttendees());
+    Set<String> allAttendeesOptional = new HashSet<String>(request.getAttendees());
+    allAttendeesOptional.addAll(request.getOptionalAttendees());
     //Add all events that attendees go to
     for (Event event : events) {
         Set<String> curAttendees = new HashSet<String>(attendees);
+        Set<String> curAttendeesOptional = new HashSet<String>(allAttendeesOptional);
         curAttendees.retainAll(event.getAttendees());
+        curAttendeesOptional.retainAll(event.getAttendees());
         if (!(curAttendees.isEmpty())){
-            allEvents.add(event);
+            allEvents.add(event);    
+        } 
+        if(!(curAttendeesOptional.isEmpty())){
+            allEventsOptional.add(event);
         }
+        
     }
     Collections.sort(allEvents);
+    Collections.sort(allEventsOptional);
+    ArrayList<TimeRange> timesOptional = getTimes(allEventsOptional, request);
+    if (!(timesOptional.isEmpty())){
+        return timesOptional;
+    }
+    ArrayList<TimeRange> times = getTimes(allEvents, request);
+    return times;
+  }
 
+  private ArrayList<TimeRange> getTimes(ArrayList<Event> allEvents, MeetingRequest request) {
     ArrayList<TimeRange> times = new ArrayList();
     int start = 0;
     Boolean cont = false;
@@ -58,7 +76,6 @@ public final class FindMeetingQuery {
             if ((long) curRange.duration() >= request.getDuration()) {
                 times.add(curRange);
             }
-
         }
     }
     if (allEvents.size() == 0 && request.getDuration() <= TimeRange.END_OF_DAY) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -14,10 +14,54 @@
 
 package com.google.sps;
 
-import java.util.Collection;
+import java.util.*;
 
 public final class FindMeetingQuery {
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    long duration = request.getDuration();
+    ArrayList<Event> allEvents = new ArrayList();
+    Set<String> attendees = new HashSet<String>(request.getAttendees());
+    for (Event event : events) {
+        Set<String> curAttendees = new HashSet<String>(attendees);
+        curAttendees.retainAll(event.getAttendees());
+        if (!(curAttendees.isEmpty())){
+            allEvents.add(event);
+        }
+    }
+    Collections.sort(allEvents);
+
+    ArrayList<TimeRange> times = new ArrayList();
+    int start = 0;
+    Boolean cont = false;
+    for (int i = 0; i < allEvents.size(); i++) {
+        TimeRange curTime = allEvents.get(i).getWhen();
+        if (!cont) {
+            TimeRange curRange = TimeRange.fromStartEnd(start, curTime.start(), false);
+            if ((long) curRange.duration() >= request.getDuration()) {
+                times.add(curRange);
+            }
+            
+        }
+        if ((i != allEvents.size() - 1) && curTime.overlaps(allEvents.get(i+1).getWhen())) {
+            cont = true;
+        } else {
+            start = curTime.end();
+            cont = false;
+        }
+
+        if (i == allEvents.size() - 1) {
+            TimeRange curRange = TimeRange.fromStartEnd(start, 1440, false);
+            if ((long) curRange.duration() >= request.getDuration()) {
+                times.add(curRange);
+            }
+
+        }
+    }
+    if (allEvents.size() == 0) {
+        times.add(TimeRange.fromStartEnd(0, 1440, false));
+    }
+    return times;
   }
+  
+
 }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,6 +34,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -43,6 +44,7 @@ public final class FindMeetingQueryTest {
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
 
+  private static final int DURATION_15_MINUTES = 15;
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
   private static final int DURATION_90_MINUTES = 90;
@@ -270,5 +272,73 @@ public final class FindMeetingQueryTest {
 
     Assert.assertEquals(expected, actual);
   }
+  @Test 
+  public void disregardOptionalAttendee() {
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
+            Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+  @Test
+  public void considerOptionalAttendee() {
+    Collection<Event> events = Arrays.asList(
+    new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+        Arrays.asList(PERSON_A)),
+    new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+        Arrays.asList(PERSON_B)),
+    new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+        Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+  @Test 
+  public void disregardIfNoFit() {
+      // Have one person, but make it so that there is just enough room at one point in the day to
+    // have the meeting.
+    //
+    // Events  : |--A--|     |----A----|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_15_MINUTES),
+            Arrays.asList(PERSON_B))    
+    );
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
 }
 


### PR DESCRIPTION
Test robustness of the optional attendees algorithm, currently add 3 tests as follows:

Checks to see if optional attendees can make make and if they can't return mandatory attendees schedule

Checks to see if times are reduced if optional attendees can make the event